### PR TITLE
Add `with_http_client` method to ImgurClient

### DIFF
--- a/src/imgur/mod.rs
+++ b/src/imgur/mod.rs
@@ -24,6 +24,22 @@ impl ImgurClient {
         let client = reqwest::Client::new();
         ImgurClient { client_id, client }
     }
+    
+    /// Create a new Imgur Client with the provided `reqwest::Client`
+    ///
+    /// This allows for customization of the http client settings like timeout or the user agent. 
+    /// ```
+    /// use imgurs::ImgurClient;
+    /// use reqwest::Client;
+    ///
+    /// let http_client = Client::builder().build();
+    ///
+    /// let client = ImgurClient::with_http_client("3e3ce0d7ac14d56", http_client);
+    /// ```
+    pub fn new(client_id: &str, http_client: reqwest::Client) -> Self {
+        let client_id = client_id.to_string();
+        ImgurClient { client_id, client: http_client }
+    }
 
     /// Upload image to Imgur
     /// ```


### PR DESCRIPTION
This will allow customization of the http client or just providing an already existing http client. In my use case I already have a client I'd like to reuse.